### PR TITLE
fix Userdata for data volume

### DIFF
--- a/cloudca.go
+++ b/cloudca.go
@@ -25,10 +25,10 @@ const (
 	userDataToMountVolume = `#cloud-config
 fs_setup:
    - label:  data
-     filesystem: 'btrfs'
+     filesystem: 'ext4'
      device: '/dev/xvdb'
 mounts:
- - [ xvdb, /var/lib/docker, "auto", "defaults", "0", "0" ]
+  - [ xvdb, /var/lib/docker, "ext4", "defaults", "0", "0" ]
 coreos:
   units:
     - name: format-datavolume.service
@@ -61,7 +61,8 @@ coreos:
           content: |
             [Unit]
             After=var-lib-docker.mount
-            Requires=var-lib-docker.mount`
+            Requires=var-lib-docker.mount
+`
 )
 
 type configError struct {

--- a/cloudca.go
+++ b/cloudca.go
@@ -22,10 +22,46 @@ const (
 	defaultSSHUser        = "cca-user"
 	dockerPort            = 2376
 	swarmPort             = 3376
-	userDataToMountVolume = `#!/bin/sh
-mkfs -t ext4 /dev/xvdb
-mkdir -p /var/lib/docker
-mount -t ext4 /dev/xvdb /var/lib/docker`
+	userDataToMountVolume = `#cloud-config
+fs_setup:
+   - label:  data
+     filesystem: 'btrfs'
+     device: '/dev/xvdb'
+mounts:
+ - [ xvdb, /var/lib/docker, "auto", "defaults", "0", "0" ]
+coreos:
+  units:
+    - name: format-datavolume.service
+      command: start
+      content: |
+        [Unit]
+        Description=Formats the data volume
+        After=dev-xvdb.device
+        Requires=dev-xvdb.device
+        ConditionPathExists=!/var/lib/docker.btrfs
+        [Service]
+        Type=oneshot
+        RemainAfterExit=yes
+        ExecStart=/usr/sbin/mkfs.btrfs /dev/xvdb
+        ExecStart=/usr/bin/mkdir /var/lib/docker.btrfs
+    - name: var-lib-docker.mount
+      command: start
+      content: |
+        [Unit]
+        Description=Mount data volume to /var/lib/docker
+        Requires=format-datavolume.service
+        After=format-datavolume.service
+        [Mount]
+        What=/dev/xvdb
+        Where=/var/lib/docker
+        Type=btrfs
+    - name: docker.service
+      drop-ins:
+        - name: 10-wait-docker.conf
+          content: |
+            [Unit]
+            After=var-lib-docker.mount
+            Requires=var-lib-docker.mount`
 )
 
 type configError struct {


### PR DESCRIPTION
Use cloud-init to Permanently mount data volume into `/var/lib/docker`. 
tested with CoreOS and Ubuntu 16.04.

if Ubuntu is rebooted, rancher-agent will automatically reconnect. on CoreOS, docker daemon is not start automatically after a reboot or upgrade,  so a manual command (`docker ps`) must be sent for now.

It is not possible to use btrfs as filesystem on ubuntu, rancher fail to deploy docker for some reason.

#2 
